### PR TITLE
Add CraftStore Fixed and Improved Plugin

### DIFF
--- a/AutoCategory.txt
+++ b/AutoCategory.txt
@@ -1,11 +1,11 @@
 ## Title: AutoCategory
 ## APIVersion: 100030 100029
-## Author: Shadowfen, crafty35a, RockingDice 
+## Author: Shadowfen, crafty35a, RockingDice, RufusRedBeard
 ## Description: Type "/ac" for settings
 ## Version: 2.3.1
 ## SavedVariables: AutoCategorySavedVars
 ## DependsOn: LibAddonMenu-2.0 LibSFUtils LibMediaProvider-1.0 LibDebugLogger
-## OptionalDependsOn: InventoryGridView GearChangerByIakoni FCOItemSaver QuickMenu ItemSaver
+## OptionalDependsOn: InventoryGridView GearChangerByIakoni FCOItemSaver QuickMenu ItemSaver, CraftStoreFixedAndImproved
 
 lang/strings.lua
 lang/$(language).lua
@@ -25,6 +25,7 @@ Misc_Plugins.lua
 ItemSaver_Plugin.lua
 FCOIS_Plugin.lua
 Iakoni_GearChanger_Plugin.lua
+CraftStoreFAI_Plugin.lua
 
 ; old integration with other addons files
 AutoCategory_Integrations_Inventory_Grid_View.lua

--- a/CraftStoreFAI_Plugin.lua
+++ b/CraftStoreFAI_Plugin.lua
@@ -1,0 +1,36 @@
+-- A very simple plugin for CraftStoreFixedAndImproved that has a single rule function to register.
+--
+-- No strings or predefined rules to load.
+
+local AC = AutoCategory
+local CS = CraftStoreFixedAndImprovedLongClassName
+
+AutoCategory_CraftStoreFAI = {
+    RuleFunc = {},
+}
+
+--Initialize plugin for Auto Category - CraftStoreFixedAndImproved
+function AutoCategory_CraftStoreFAI.Initialize()
+	if not CS then
+		AC.AddRuleFunc("isstoredforcraftstore", AC.dummyRuleFunc)
+	else
+        AC.AddRuleFunc("isstoredforcraftstore", AutoCategory_CraftStoreFAI.RuleFunc.IsStoredForCraftStore)
+    end
+end
+
+-- Implement isstoredforcraftstore() check function for CraftStore Fixed and Improved
+function AutoCategory_CraftStoreFAI.RuleFunc.IsStoredForCraftStore( ... )
+	if CS == nil then
+		return false
+	end
+	local itemID = Id64ToString(GetItemUniqueId(AC.checkingItemBagId, AC.checkingItemSlotIndex))
+	local isStored = CS.IsItemStoredForCraftStore(itemID)
+	if isStored then
+	  local itemLink = GetItemLink(AC.checkingItemBagId, AC.checkingItemSlotIndex)
+	  d("Item Stored for CraftStore : " .. itemLink .. " ID : " .. itemID)
+    end
+	return isStored
+end
+
+-- Register this plugin with AutoCategory to be initialized and used when AutoCategory loads.
+AC.RegisterPlugin("CraftStoreFAI", AutoCategory_CraftStoreFAI.Initialize)


### PR DESCRIPTION
Plugin adds isstoredforcraftstore() function that can be used in place of keepresearch().

CraftStore Fixed and Improved has a very comprehensive system for deciding what each character wants to research and what it does not. Then tracks items that are needed by one toon for research across all characters.

This function exposes the purple status icon CS adds next to items that are needed by one of your toons for research.

For people with multiple toons that don't all research all items or even if you only have one toon that wants to research a subset of items, this is a much more useful category than the base capability.

I didn't find the documentation in the source tree so not proposing doc changes. I'm also not sure what kind of testing you'd like to see. Please let me know if you'd like any changes at all.